### PR TITLE
Create parent dirs of output files

### DIFF
--- a/src/leiningen/sass.clj
+++ b/src/leiningen/sass.clj
@@ -69,7 +69,9 @@
       (if (string? compiled)
         (do
           (println "compiled successfully")
-          (spit (str target File/separator (ext-sass->css file-name)) compiled))
+          (let [output-file-path (str target File/separator (ext-sass->css file-name))]
+            (io/make-parents output-file-path)
+            (spit output-file-path compiled)))
         (do
           (println "failed to compile:" file-name)
           (clojure.pprint/pprint compiled))))))


### PR DESCRIPTION
The plugin currently throws an exception if the parent directories of output files don't exist already.  This PR creates the output parent directories if necessary.