### PR TITLE
exclude partial files from build process

### DIFF
--- a/src/leiningen/sass.clj
+++ b/src/leiningen/sass.clj
@@ -55,7 +55,8 @@
     (if (.isDirectory f)
       (->> f
            file-seq
-           (filter (fn [file] (-> file .getName (.endsWith ext)))))
+           (filter (fn [file] (-> file .getName (.endsWith ext))))
+           (filter (fn [file] (-> file .getName (.startsWith "_") not))))
       [f])))
 
 (defn ext-sass->css [file-name]


### PR DESCRIPTION
Hi this change filters out [partial files](http://sass-lang.com/guide) from build process which is default behavior for all sass/scss compiler in the wild. Would you consider merging it in? Currently I have lots of problem with compiling scss libraries like bootstrap.