### PR TITLE
write source mapping url to target file

### DIFF
--- a/src/leiningen/sass.clj
+++ b/src/leiningen/sass.clj
@@ -133,6 +133,7 @@
           (let [map-file-path (str output-file-path ".map")]
             (io/make-parents output-file-path)
             (spit output-file-path text)
+            (spit output-file-path (format "\n/*# sourceMappingURL=%s.map */\n" file-name) :append true)
             (spit map-file-path map)))))))
 
 (defn sass [{{:keys [source target]} :sass} & opts]


### PR DESCRIPTION
this will make source maps automatically discoverable in browser's dev tools