### PR TITLE
A bug fix and a suggestion

### DIFF
--- a/src/leiningen/sass.clj
+++ b/src/leiningen/sass.clj
@@ -217,7 +217,9 @@
     (if (some #{"watch"} opts)
       (do
         (compile-assets files-without-partials target)
-        (watch-thread source (fn [e] (compile-assets files target))))
+        (watch-thread source (fn [e]
+                               (register-files-for-import files)
+                               (compile-assets files-without-partials target))))
       (when (not @compiled?)
         (compile-assets files-without-partials target)
         (reset! compiled? true)))))


### PR DESCRIPTION
So, I forgot to check that 'lein sass watch' works with the partial files. It didn't but does now. Also, I added one exception handling case.
The suggestion is that when there is some sort of a file structure in the source, it should be preserved in the output as well. For instance, if source is 'src/sass' and target is 'resources/public/css' then a file 'src/sass/foo/bar.scss' should end up in 'resources/public/css/foo/bar.css'. At the moment it is compiled into 'resources/public/css/bar.css'. This can cause file overriding. For example, if I had two different files 'src/sass/foo/bar.scss' and 'src/sass/asd/bar.scss' then the latter would override the former when compiled into a .css file.